### PR TITLE
Move pcb->poll to eliminate accesses to unallocated memory

### DIFF
--- a/src/core/altcp_tcp.c
+++ b/src/core/altcp_tcp.c
@@ -323,14 +323,13 @@ altcp_tcp_close(struct altcp_pcb *conn)
   pcb = (struct tcp_pcb *)conn->state;
   if (pcb) {
     err_t err;
-    tcp_poll_fn oldpoll = pcb->poll;
     altcp_tcp_remove_callbacks(pcb);
     err = tcp_close(pcb);
     if (err != ERR_OK) {
       /* not closed, set up all callbacks again */
       altcp_tcp_setup_callbacks(conn, pcb);
       /* poll callback is not included in the above */
-      tcp_poll(pcb, oldpoll, pcb->pollinterval);
+      tcp_poll(pcb, pcb->poll, pcb->pollinterval);
       return err;
     }
     conn->state = NULL; /* unsafe to reference pcb after tcp_close(). */


### PR DESCRIPTION
If the pcb is a tcp_pcb_listen struct, then the pcb->poll may access unallocated memory. We move the pcb->poll location to mitigate this issue.