### PR TITLE
Only access poll if the pcb state is not LISTEN

### DIFF
--- a/src/core/altcp_tcp.c
+++ b/src/core/altcp_tcp.c
@@ -323,7 +323,7 @@ altcp_tcp_close(struct altcp_pcb *conn)
   pcb = (struct tcp_pcb *)conn->state;
   if (pcb) {
     err_t err;
-    tcp_poll_fn oldpoll = pcb->poll;
+    tcp_poll_fn oldpoll = pcb->state != LISTEN ? pcb->poll : NULL;
     altcp_tcp_remove_callbacks(pcb);
     err = tcp_close(pcb);
     if (err != ERR_OK) {

--- a/src/core/altcp_tcp.c
+++ b/src/core/altcp_tcp.c
@@ -330,7 +330,9 @@ altcp_tcp_close(struct altcp_pcb *conn)
       /* not closed, set up all callbacks again */
       altcp_tcp_setup_callbacks(conn, pcb);
       /* poll callback is not included in the above */
-      tcp_poll(pcb, oldpoll, pcb->pollinterval);
+      if (pcb->state != LISTEN) {
+        tcp_poll(pcb, oldpoll, pcb->pollinterval);
+      }
       return err;
     }
     conn->state = NULL; /* unsafe to reference pcb after tcp_close(). */


### PR DESCRIPTION
If the pcb state is LISTEN, then the tcp_poll_fn should not exist. The previous access would have accessed unallocated memory.

The pcb struct for LISTEN is: https://github.com/extensible-internet/lwip/blob/124dc0a64ef5d7c14a27e3115e5888df6559cb72/src/include/lwip/tcp.h#L223-L238